### PR TITLE
PWA 401対応

### DIFF
--- a/app/views/header.html
+++ b/app/views/header.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="/public/css/bootstrap-3.3.6.min.css">
   <link rel="shortcut icon" type="image/png" href="/public/img/favicon.png">
   <link rel="stylesheet" type="text/css" href="/public/css/bootstrap-tagsinput.css">
-  <link rel="manifest" href="/public/manifest.json">
+  <link rel="manifest" href="/public/manifest.json" crossorigin="use-credentials">
   <script>
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('/public/js/service-worker.js', {scope: "/"}).then(function(registration) {


### PR DESCRIPTION
`GET https://diary.aokabi.me/public/manifest.json 401 (Unauthorized)` が無限に出るので対応．

https://developer.mozilla.org/en-US/docs/Web/Manifest#:~:text=application/json).-,If%20the%20manifest%20requires%20credentials%20to%20fetch%2C%20the%20crossorigin%20attribute%20must%20be%20set%20to%20use%2Dcredentials%2C%20even%20if%20the%20manifest%20file%20is%20in%20the%20same%20origin%20as%20the%20current%20page.,-%3Clink%20rel